### PR TITLE
namespacing: OPS calls through dict

### DIFF
--- a/devito/ops/node_factory.py
+++ b/devito/ops/node_factory.py
@@ -20,16 +20,16 @@ class OPSNodeFactory(object):
 
     def new_ops_arg(self, indexed):
         """
-        Create an :class:`Indexed` node using OPS representation.
+        Create an Indexed node using OPS representation.
 
         Parameters
         ----------
-        indexed : :class:`Indexed`
+        indexed : Indexed
             Indexed object using devito representation.
 
         Returns
         -------
-        :class:`Indexed`
+        Indexed
             Indexed node using OPS representation.
         """
 

--- a/devito/ops/operator.py
+++ b/devito/ops/operator.py
@@ -3,6 +3,8 @@ from devito.logger import warning
 from devito.operator import Operator
 from devito.types.basic import FunctionPointer
 
+from devito.ops.utils import namespace
+
 __all__ = ['OperatorOPS']
 
 
@@ -18,8 +20,10 @@ class OperatorOPS(Operator):
 
         warning("The OPS backend is still work-in-progress")
 
-        ops_init = Call("ops_init", [0, 0, 2])
-        ops_timing = Call("ops_timing_output", [FunctionPointer("stdout")])
-        ops_exit = Call("ops_exit")
+        ops_init = Call(namespace['ops_init'], [0, 0, 2])
+        ops_timing = Call(namespace['ops_timing_output'], [FunctionPointer("stdout")])
+        ops_exit = Call(namespace['ops_exit'])
 
-        return List(body=[ops_init, iet, ops_timing, ops_exit])
+        body = [ops_init, iet, ops_timing, ops_exit]
+        
+        return List(body=body)

--- a/devito/ops/transformer.py
+++ b/devito/ops/transformer.py
@@ -5,14 +5,14 @@ def make_ops_ast(expr, nfops):
 
     Parameters
     ----------
-    expr : :class:`Node`
+    expr : Node
         Initial tree node.
-    nfops : :class:`OPSNodeFactory`
+    nfops : OPSNodeFactory
         Generate OPS specific nodes.
 
     Returns
     -------
-    :class:`Node`
+    Node
         Expression alredy translated to OPS syntax.
     """
 

--- a/devito/ops/utils.py
+++ b/devito/ops/utils.py
@@ -6,3 +6,6 @@ namespace = OrderedDict()
 
 # OPS Kernel strings.
 namespace['ops_acc'] = 'OPS_ACC'
+namespace['ops_init'] = 'ops_init'
+namespace['ops_timing_output'] = 'ops_timing_output'
+namespace['ops_exit'] = 'ops_exit'


### PR DESCRIPTION
This PR is for making sure that all OPS invcations are
made trought `namespace` dictionary.

It also updates docstring: removing `class` from text.